### PR TITLE
issue: 4297354: Utility for plugin config file upgrade should not remove comments from config file

### DIFF
--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -32,9 +32,7 @@ CFG_LINE_RGX = r"^(\S+)\s*=\s*(.*)$"
 def setup_logger(plugin_name=None, log_level=None):
     """Configures and returns a logger that sends logs to syslog."""
     logging.basicConfig(
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    datefmt="%b %d %H:%M:%S"
-    )
+    format="%[%(levelname)s] %(name)s: %(message)s")
     logger_name = f'ufm-plugin-{plugin_name}-configurations-merger' if plugin_name else 'ufm-plugin-configurations-merger'
     logger = logging.getLogger(logger_name)
     if log_level:

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -31,36 +31,16 @@ CFG_LINE_RGX = r"^(\S+)\s*=\s*(.*)$"
 
 def setup_logger(plugin_name=None, log_level=None):
     """Configures and returns a logger that sends logs to syslog."""
+    logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%b %d %H:%M:%S"
+    )
     logger_name = f'ufm-plugin-{plugin_name}-configurations-merger' if plugin_name else 'ufm-plugin-configurations-merger'
     logger = logging.getLogger(logger_name)
     if log_level:
         logger.setLevel(getattr(logging, log_level, logging.INFO))
     else:
         logger.setLevel(logging.INFO)
-    formatter = logging.Formatter(
-            fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            datefmt="%b %d %H:%M:%S"
-        )
-
-    syslog_handler = None
-
-    try:
-        # First attempt /dev/log (default for most Unix-like systems)
-        syslog_handler = SysLogHandler(address="/dev/log")
-    except Exception:
-        try:
-            # Fallback for Red Hat or others that use /var/run/syslog
-            syslog_handler = SysLogHandler(address="/var/run/syslog")
-        except Exception:
-            handler = logging.StreamHandler()
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-            logger.warning("Syslog is not available on this system. Logging to console instead.")
-
-    if syslog_handler:
-        syslog_handler.setFormatter(formatter)
-        logger.addHandler(syslog_handler)        
-
     return logger
 
 def merge_ini_files(old_file_path, new_file_path, merged_file_path):

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -41,6 +41,25 @@ def setup_logger(plugin_name=None, log_level=None):
     return logger
 
 def merge_ini_files(old_file_path, new_file_path, merged_file_path):
+    """
+    Merges two INI configuration files while preserving structure and comments.
+
+    This function takes an existing INI file (`old_file_path`) and a new INI file (`new_file_path`), 
+    and generates a merged INI file (`merged_file_path`). The merging process ensures:
+      - Section headers are preserved.
+      - Key-value pairs from `new_file_path` are checked against `old_file_path`. 
+        If a key exists in both, the value from `old_file_path` is retained.
+      - Non-key lines, including empty lines and comments, are preserved from `new_file_path`.
+
+    Args:
+        old_file_path (str): Path to the original INI file.
+        new_file_path (str): Path to the new INI file.
+        merged_file_path (str): Path where the merged INI file will be saved.
+
+    Returns:
+        bool: True if merging is successful, False if any file is missing or an error occurs.
+    """
+    
     # Check if files exist
     for file_path in (old_file_path, new_file_path):
         if not os.path.isfile(file_path):
@@ -80,7 +99,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
                     old_file.write(line)  # Preserve non-key lines (empty lines, comments)
    
     except Exception:
-        logger.exception("Failed to process a line or to write to merge file: %s")
+        logger.exception("Failed to process a line or to write to merge file: %s" % old_file)
         return False
 
     return True
@@ -127,11 +146,14 @@ if __name__ == "__main__":
                 logger.info("Configuration file %s upgraded successfully." % old_file)
             except Exception:
                 logger.exception("Failed to move upgraded file from %s to %s. Reverting changes." % (tmp_merged_file, old_file))
+                exit(1)
                 
                 # Attempt to restore the original file from backup
                 shutil.move(backup_path, old_file)
                 logger.info("Reverted to original configuration file %s." % old_file)
+                exit(1)
 
         except Exception:
             logger.exception("Failed to move old configuration file to backup, from %s to %s." % (old_file, backup_path))
-
+            exit(1)
+            

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -92,7 +92,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
                 else:
                     old_file.write(line)  # Preserve non-key lines (empty lines, comments)
    
-    except Exception as e:
+    except Exception:
         logger.exception("Failed to process a line or to write to merge file: %s")
         return False
 
@@ -133,5 +133,5 @@ if __name__ == "__main__":
             shutil.move(tmp_merged_file, old_file)
             logger.info("Configuration file upgraded successfully.")
 
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to move upgraded file from %s to %s." % (tmp_merged_file, old_file))

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -72,7 +72,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
 
     res = config_old.read(old_file_path)
     if not res:
-        logger.error("Error: Failed to read file %s" % old_file_path)
+        logger.error("Error: Failed to read file %s", old_file_path)
         return False
 
     try:
@@ -99,7 +99,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
                     old_file.write(line)  # Preserve non-key lines (empty lines, comments)
    
     except Exception:
-        logger.exception("Failed to process a line or to write to merge file: %s" % old_file)
+        logger.exception("Failed to process a line or to write to merge file: %s", old_file)
         return False
 
     return True
@@ -129,12 +129,12 @@ if __name__ == "__main__":
     result = merge_ini_files(old_file, new_file, tmp_merged_file)
 
     if not result:
-        logger.error("Configuration file %s upgrade failed." % old_file)
+        logger.error("Configuration file %s upgrade failed.", old_file)
         exit(1)
 
     else:
         try:
-            logger.info("Move upgraded file %s to initial location %s" % (tmp_merged_file, old_file))
+            logger.info("Move upgraded file %s to initial location %s", tmp_merged_file, old_file)
             
             # Move old file to backup
             backup_path = f"{old_file}.backup"
@@ -143,17 +143,17 @@ if __name__ == "__main__":
             try:
                 # Move new file to old file location
                 shutil.move(tmp_merged_file, old_file)
-                logger.info("Configuration file %s upgraded successfully." % old_file)
+                logger.info("Configuration file %s upgraded successfully.", old_file)
             except Exception:
-                logger.exception("Failed to move upgraded file from %s to %s. Reverting changes." % (tmp_merged_file, old_file))
+                logger.exception("Failed to move upgraded file from %s to %s. Reverting changes.", tmp_merged_file, old_file)
                 exit(1)
                 
                 # Attempt to restore the original file from backup
                 shutil.move(backup_path, old_file)
-                logger.info("Reverted to original configuration file %s." % old_file)
+                logger.info("Reverted to original configuration file %s.", old_file)
                 exit(1)
 
         except Exception:
-            logger.exception("Failed to move old configuration file to backup, from %s to %s." % (old_file, backup_path))
+            logger.exception("Failed to move old configuration file to backup, from %s to %s.", old_file, backup_path)
             exit(1)
             

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -60,7 +60,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
 
     res = config_old.read(old_file_path)
     if not res:
-        logger.error("Error: %s exists but could not be read properly.", old_file_path)
+        logger.error(f"Error: Failed to read file {old_file_path}")
         return False
 
     try:
@@ -82,12 +82,12 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
                     if config_old.has_section(section) and config_old.has_option(section, key):
                         new_value = (config_old.get(section, key)).strip()
                     # Write back the line with preserved comments
-                    of.write("%s = %s\n" % (key, new_value))
+                    of.write(f"{key} = {new_value}\n")
                 else:
                     of.write(line)  # Preserve non-key lines (empty lines, comments)
    
     except Exception as e:
-        logger.error("An unexpected error occurred: %s" % e)
+        logger.error(f"Failed to process a line or to write to merge file: {e}")
         return False
 
     return True
@@ -115,12 +115,9 @@ if __name__ == "__main__":
 
         try:
             logger.info("Configuration file upgraded successfully.")
-            logger.info("Move upgraded file %s to initial location %s" % (tmp_merged_file, new_file))
-            shutil.move(new_file, "%s.backup" % old_file)
+            logger.info(f"Move upgraded file {tmp_merged_file} to initial location {new_file}")
+            shutil.move(new_file, f"{old_file}.backup")
             shutil.move(tmp_merged_file, new_file)
 
         except Exception as e:
-            logger.error("An unexpected error occurred: %s" % e)
-        
-        
-
+            logger.error(f"Failed to move upgraded file: {e}")

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -31,7 +31,7 @@ CFG_LINE_RGX = r"^(\S+)\s*=\s*(.*)$"
 
 def setup_logger(plugin_name=None, log_level=None):
     """Configures and returns a logger that sends logs to syslog."""
-    logging.basicConfig(format="%[%(levelname)s] %(name)s: %(message)s")
+    logging.basicConfig(format="[%(levelname)s] %(name)s: %(message)s")
     logger_name = f'ufm-plugin-{plugin_name}-configurations-merger' if plugin_name else 'ufm-plugin-configurations-merger'
     logger = logging.getLogger(logger_name)
     if log_level:

--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -31,8 +31,7 @@ CFG_LINE_RGX = r"^(\S+)\s*=\s*(.*)$"
 
 def setup_logger(plugin_name=None, log_level=None):
     """Configures and returns a logger that sends logs to syslog."""
-    logging.basicConfig(
-    format="%[%(levelname)s] %(name)s: %(message)s")
+    logging.basicConfig(format="%[%(levelname)s] %(name)s: %(message)s")
     logger_name = f'ufm-plugin-{plugin_name}-configurations-merger' if plugin_name else 'ufm-plugin-configurations-merger'
     logger = logging.getLogger(logger_name)
     if log_level:
@@ -111,7 +110,7 @@ if __name__ == "__main__":
     result = merge_ini_files(old_file, new_file, tmp_merged_file)
 
     if not result:
-        logger.error("Configuration file upgrade failed.")
+        logger.error("Configuration file %s upgrade failed." % old_file)
         exit(1)
 
     else:
@@ -125,13 +124,13 @@ if __name__ == "__main__":
             try:
                 # Move new file to old file location
                 shutil.move(tmp_merged_file, old_file)
-                logger.info("Configuration file upgraded successfully.")
+                logger.info("Configuration file %s upgraded successfully." % old_file)
             except Exception:
                 logger.exception("Failed to move upgraded file from %s to %s. Reverting changes." % (tmp_merged_file, old_file))
                 
                 # Attempt to restore the original file from backup
                 shutil.move(backup_path, old_file)
-                logger.info("Reverted to original configuration file.")
+                logger.info("Reverted to original configuration file %s." % old_file)
 
         except Exception:
             logger.exception("Failed to move old configuration file to backup, from %s to %s." % (old_file, backup_path))


### PR DESCRIPTION
What:
Improve the merge_configuration_files.py script, which is used in the plugin upgrade process.

Why?
1. The merge between configuration files of the old and new versions should not remove comments in the .cfg file.
2. The merged .cfg file should not override the original file but should save it as a backup.
3. Log messages should be forwarded to syslog.
Link for bug: https://redmine.mellanox.com/issues/4297354

How:
1. Retain comments by parsing the new .cfg file with regex instead of using the configparser package (which ignores comments).
2. Write the merged configurations into a temporary file.
3. Forward log messages to syslog.

Testing:
1. Manually tested end-to-end.
2. Automation pytest was written for the merge_ini_files function.

Special triggers:
Use the following phrases as comments to trigger different runs:

bot:retest – rerun Jenkins CI (for rerunning GitHub CI, use the "Checks" tab on the PR page and rerun all jobs).
bot:upgrade – run additional update tests.