### PR TITLE
issue:4337415: [Plugins infra]: Add singleton metaclass to the ufm_sdk_tools repo

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,11 @@
+#
+# Copyright © 2020-2025 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#

--- a/src/utils/singleton.py
+++ b/src/utils/singleton.py
@@ -1,0 +1,30 @@
+#
+# Copyright © 2020-2025 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# This software product is a proprietary product of Nvidia Corporation and its affiliates
+# (the "Company") and all right, title, and interest in and to the software
+# product, including all associated intellectual property rights, are and
+# shall remain exclusively with the Company.
+#
+# This software product is governed by the End User License Agreement
+# provided with the software product.
+#
+
+# author: Samer Deeb
+# date:   Oct 8, 2020
+#
+
+
+class SingletonMeta(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in SingletonMeta._instances:
+            single_obj = super(SingletonMeta, cls).__call__(*args, **kwargs)
+            SingletonMeta._instances[cls] = single_obj
+        return cls._instances[cls]
+
+
+def _forget_singleton_for_testing(cls):
+    # pylint: disable=protected-access
+    SingletonMeta._instances.pop(cls, None)


### PR DESCRIPTION
### What?
Added a `SingletonMeta` metaclass utility to be used across various UFM plugins.

### Why?
Currently, multiple plugins implement their own redundant singleton logic. Adding this utility to this shared repository ensures consistency, reduces duplication