### PR TITLE
issue:4295173 Improve logger initialization and handling in config merge utility

### DIFF
--- a/src/config_parser_utils/merge_configuration_files.py
+++ b/src/config_parser_utils/merge_configuration_files.py
@@ -29,8 +29,12 @@ import re
 # Captures the "key" (non-whitespace) and the "value" (any characters).
 CFG_LINE_RGX = r"^(\S+)\s*=\s*(.*)$"
 
+# Logger name constants
+INITIAL_LOGGER_NAME = "ufm_plugin_conf_merger_initial"
+DEFAULT_LOGGER_NAME = "ufm-plugin-configurations-merger"
+
 # Initialize a module-level logger. Its name helps identify if it's been configured.
-logger = logging.getLogger("ufm_plugin_conf_merger_initial")
+logger = logging.getLogger(INITIAL_LOGGER_NAME)
 logger.setLevel(logging.INFO)
 
 def setup_logger(plugin_name=None, log_level_input=None):
@@ -40,7 +44,7 @@ def setup_logger(plugin_name=None, log_level_input=None):
     log_format = "[%(levelname)s] %(name)s: %(message)s"
     logging.basicConfig(format=log_format, level=logging.INFO) 
 
-    final_logger_name = 'ufm-plugin-configurations-merger'
+    final_logger_name = DEFAULT_LOGGER_NAME
     if plugin_name:
         final_logger_name = f'ufm-plugin-{plugin_name}-configurations-merger'
 
@@ -78,7 +82,7 @@ def merge_ini_files(old_file_path, new_file_path, merged_file_path):
     # If this function is called and the logger is still the initial placeholder,
     # it means __main__ block didn't run (e.g. imported as a module).
     # So, initialize the logger with default settings.
-    if logger.name == "ufm_plugin_conf_merger_initial":
+    if logger.name == INITIAL_LOGGER_NAME:
         setup_logger() # Initialize with default name and level
 
     # Check if files exist


### PR DESCRIPTION
## What
Refactored logger initialization and configuration logic within the merge_configuration_files.py script.
Enabled command-line arguments for plugin_name and log_level to customize logger behavior when the script is run directly.

## Why ?
Robustness: To prevent "variable used before assignment" errors and ensure the logger is always available and functional, regardless of whether the script is executed directly or imported as a module into another Python script (e.g., by an upgrade process). This was also highlighted by a linter warning.
Flexibility: To allow calling scripts or users to specify a custom plugin_name (which becomes part of the logger's name for easier identification in logs) and a log_level when running the merge utility directly from the command line.
Clarity: To make the logger setup more explicit and ensure that it defaults gracefully if not run from __main__.
